### PR TITLE
Update demo.py

### DIFF
--- a/demo.py
+++ b/demo.py
@@ -344,7 +344,7 @@ if __name__ == '__main__':
   im = cv2.cvtColor(im, cv2.COLOR_BGR2RGB)
   plt.imshow(im)
 
-  boxes = pred_boxes[keep_boxes]
+  boxes = pred_boxes[keep_boxes].cpu()
   objects = torch.argmax(scores[keep_boxes][:,1:], dim=1)
 
   for i in range(len(keep_boxes)):


### PR DESCRIPTION
Hi,

I tried running the following command 

`python demo.py --net res101 --dataset vg --image_file img1.jpg --cuda`

and `demo.py` crashed with the following error

```
Traceback (most recent call last):
  File "/storage/arkareem/projects/faster-rcnn/Faster-R-CNN-with-model-pretrained-on-Visual-Genome/demo.py", line 359, in <module>
    plt.gca().add_patch(
  File "/storage/arkareem/libraries/conda/lib/python3.9/site-packages/matplotlib/axes/_base.py", line 2415, in add_patch
    self._update_patch_limits(p)
  File "/storage/arkareem/libraries/conda/lib/python3.9/site-packages/matplotlib/axes/_base.py", line 2446, in _update_patch_limits
    patch_trf = patch.get_transform()
  File "/storage/arkareem/libraries/conda/lib/python3.9/site-packages/matplotlib/patches.py", line 262, in get_transform
    return self.get_patch_transform() + artist.Artist.get_transform(self)
  File "/storage/arkareem/libraries/conda/lib/python3.9/site-packages/matplotlib/patches.py", line 745, in get_patch_transform
    bbox = self.get_bbox()
  File "/storage/arkareem/libraries/conda/lib/python3.9/site-packages/matplotlib/patches.py", line 877, in get_bbox
    return transforms.Bbox.from_extents(x0, y0, x1, y1)
  File "/storage/arkareem/libraries/conda/lib/python3.9/site-packages/matplotlib/transforms.py", line 826, in from_extents
    bbox = Bbox(np.reshape(args, (2, 2)))
  File "<__array_function__ internals>", line 180, in reshape
  File "/storage/arkareem/libraries/conda/lib/python3.9/site-packages/numpy/core/fromnumeric.py", line 298, in reshape
    return _wrapfunc(a, 'reshape', newshape, order=order)
  File "/storage/arkareem/libraries/conda/lib/python3.9/site-packages/numpy/core/fromnumeric.py", line 54, in _wrapfunc
    return _wrapit(obj, method, *args, **kwds)
  File "/storage/arkareem/libraries/conda/lib/python3.9/site-packages/numpy/core/fromnumeric.py", line 43, in _wrapit
    result = getattr(asarray(obj), method)(*args, **kwds)
  File "/storage/arkareem/libraries/conda/lib/python3.9/site-packages/torch/_tensor.py", line 643, in __array__
    return self.numpy()
TypeError: can't convert cuda:0 device type tensor to numpy. Use Tensor.cpu() to copy the tensor to host memory first.
```

I simply moved the tensor to the cpu such that it doesn't crash when passed to `matplotlib`.